### PR TITLE
(tests) Improve .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,5 @@ after_script:
   - echo $BUCKET
   - echo $AWS_S3_TEST_TOP_DIRECTORY
   - ~/.local/bin/aws s3 ls --recursive $BUCKET
+  - echo ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/$AWS_S3_TEST_TOP_DIRECTORY
   - ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/$AWS_S3_TEST_TOP_DIRECTORY

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - secure: "S288kAeEv5c6nN6WUltprGjf+uUEH0/1q2uDVfvqfvefYSOQeQ5ZpnEkJfOAp1e1zqQW2Ff/4gg5D60Vz8TS70NjtlUBWW6RWy7vmvjrPfpOsuKNSep+0PJNkkDLeXMikkCdIcZ/+rCdn95vmV3xgWj2ueINyn5mXHjkcOPms6Sdn0qRAziT+BBI31WcLU4/7138JXs7Oay/BhINfUZq6E0Hv8mze48iTr7B0zBGzH0qPtQjzn86t0KIN6v3lDbU6FMLWZJjKh0ugibji2jjUNWmTqq/4e4qcVZq8bcFoxvQ+QKu26Vgk8b7q6YsKis18sW3cwV4sZprsvun7+K97wyrTqyriLLZyGomcRuczp6CiNAn8xkhTE20miq5Ff2shOm5wtYxzvr/HqzvsV8QjDl65OecSdWNAflmweFpqsLaajL6t03cisRUFU+KxQ5Yu2YEOEtUSsvHAvwlQEsIf6fOp34U+LrGbPSvom7cvbXDK1kgvQGiJqZgsq3vSWFM8KpMrAd9kU8vTs+WOn0ppzEzgVbajF1SYjrxmWZuiIc4CR4obng9sQymYdYnuDAqS4cg2rqQ4L6dQwbVezoobLw8ObjEhru8y7t4CgtGhN8so6UKT1WLIZzl/xg6Jud/mNvDwDptvXoBXXAXp+vppka+RudKgpUu6trgcYI+kQI="
     - secure: "cQxAj3BlT4eVd60X8Zm6TQBQhSbdk0/tx0CNwQRdVpOvcBykcJv2I5YJRtyPEyZuqKEbswM5nZwdpG2K9CUUntB5BbIlRjh4/zFHpiMvQynUPDYG4WUJo8NpnuTfLbRUh0Z/CD90GvnCjp6kdltHpy9Lhy4KYqrsdFxAwX45NkftnBWyZL/4SYR0SlvWsHGfvdGeAm1MBeLmoHFJBEc0116qQF4dhL5ZQxVEy5dqKc18FzuUhNduoiz4TQlsHOw6g+brc9VoqOpzGxODfgGozHfIQyYU6uYtr68ksXNtabfOyGVPHZ8eGbdhtQ2AaD0/VxUdQIINDhSD+U886GvzA32LEduieaDiMtbn9k2eQiVQE0X4fNk61sQFsdrPPNk99S0QYugUc94vDLpUbVPtFlT66GAs8qFedY9xKc2YKAfoupMx0nsE4bHvXw8AKARZs4XB+w9aUGzux8msjM2GUPMogCsYWOrnC+4NI91SYGtWxXvnRW34q5mY3Z1QhZA2Rk1gGje25G/rpn5XkKtUttFsFe8IWHdff1k252HTiInSGTgp/Nnhjb16iN/r4ACWLHbBkqRNBAE/SeZWStFqWO3WnQlQMjYseosqsFBo9pmIpZJligzgndj8v5EhfTOr0Ian5iDrkeOYZ4oKZPAiEWtbnj5RaayzyZmfVdkGQ6o="
     - secure: "qM9BmDBPaj72YTJnvhYBm39uxvenQMEf/pEWzSeO6/B7FGfvtSxdUPz67G0QrGNsbOdUo2y/CppBCltqg/JUvpMHbrtO/vWgFUgPKrZNiyxjhvBjRIebOPc8vjXMeqCeOy5SOl33Uz6YlvYYvM4y9/sLDjgBdgPKHblMloik0r/k27BOo64avfbp0xN3HJAO6AYZ2O7wP5jmjUV8lMdr2O3BMVeP+TsXRr32BQ3SmO+sAvLiDgHnK6qjg9/3KF0GHFV4J044hQ3CXaucSPo0KeH3KarqRakQQ5WdO6m96jX88RrZDFzAJpSdRe/r9F4yDnVNYdECW4f5t2ENl3+LpEsS9LI3dyN3HN+z8t4bNI8J2NkAuUWGgspMIHP+poQSxy4i8009Dcv3CDp7viDpoTZX7dkYHKKodA2jFj3FId0fvaLlO++bvGtIjawrkKRpqH9rjn9jHy2bGl7AFmx8Ttop7p+elwaWXJ5xREWNIN5MXs0s5M402iPRgjibeQa1qp83w/eMQcwHv4LsjuJ1l9UVtXAzuCq/6GY2vc1Rqng64yqvDc9Up5rPJ3zWJbBV/t6vl/UHnAKagSpBoyhexvH73E6Ug449DWGAb7XrvcH3ZjvQdO0rjMULkrebk9SkDMrmvLrbEID2q1Yl/dAZCOTKihOnHV/xXXM9kLsGae8="
-    - BUCKET="${AWS_BUCKET_PREFIX}-img"
 
 matrix:
   include:
@@ -51,7 +50,7 @@ before_script:
   - echo -en "\n\nrequire_once __DIR__ . '/extensions/AWS/tests/travis/AWSSettings.php';\n" >> ./LocalSettings.php
   - php -l ./LocalSettings.php
   - php maintenance/update.php --quick
-  - export AWS_S3_TEST_TOP_DIRECTORY="test$(LC_ALL=C date +'%s')-$TRAVIS_JOB_NUMBER"
+  - export AWS_S3_TEST_TOP_DIRECTORY="Test$(LC_ALL=C date +'%s')-$TRAVIS_JOB_NUMBER"
 
 script:
   - php tests/phpunit/phpunit.php extensions/AWS/tests/phpunit/
@@ -61,9 +60,4 @@ after_script:
   - mkdir -p ~/.aws
   - echo -en "\n[default]\naws_access_key_id = ${AWS_KEY}\naws_secret_access_key = ${AWS_SECRET}\n" >>~/.aws/credentials
   - echo -en "\n[default]\nregion = us-east-1\n" >>~/.aws/config
-  - chmod 600 ~/.aws/*
-  - echo $BUCKET
-  - echo $AWS_S3_TEST_TOP_DIRECTORY
-  - ~/.local/bin/aws s3 ls --recursive $BUCKET
-  - echo ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/$AWS_S3_TEST_TOP_DIRECTORY
-  - ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/$AWS_S3_TEST_TOP_DIRECTORY
+  - ~/.local/bin/aws s3 rm --recursive s3://${AWS_BUCKET_PREFIX}-img/${AWS_S3_TEST_TOP_DIRECTORY}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,16 @@ env:
     - secure: "S288kAeEv5c6nN6WUltprGjf+uUEH0/1q2uDVfvqfvefYSOQeQ5ZpnEkJfOAp1e1zqQW2Ff/4gg5D60Vz8TS70NjtlUBWW6RWy7vmvjrPfpOsuKNSep+0PJNkkDLeXMikkCdIcZ/+rCdn95vmV3xgWj2ueINyn5mXHjkcOPms6Sdn0qRAziT+BBI31WcLU4/7138JXs7Oay/BhINfUZq6E0Hv8mze48iTr7B0zBGzH0qPtQjzn86t0KIN6v3lDbU6FMLWZJjKh0ugibji2jjUNWmTqq/4e4qcVZq8bcFoxvQ+QKu26Vgk8b7q6YsKis18sW3cwV4sZprsvun7+K97wyrTqyriLLZyGomcRuczp6CiNAn8xkhTE20miq5Ff2shOm5wtYxzvr/HqzvsV8QjDl65OecSdWNAflmweFpqsLaajL6t03cisRUFU+KxQ5Yu2YEOEtUSsvHAvwlQEsIf6fOp34U+LrGbPSvom7cvbXDK1kgvQGiJqZgsq3vSWFM8KpMrAd9kU8vTs+WOn0ppzEzgVbajF1SYjrxmWZuiIc4CR4obng9sQymYdYnuDAqS4cg2rqQ4L6dQwbVezoobLw8ObjEhru8y7t4CgtGhN8so6UKT1WLIZzl/xg6Jud/mNvDwDptvXoBXXAXp+vppka+RudKgpUu6trgcYI+kQI="
     - secure: "cQxAj3BlT4eVd60X8Zm6TQBQhSbdk0/tx0CNwQRdVpOvcBykcJv2I5YJRtyPEyZuqKEbswM5nZwdpG2K9CUUntB5BbIlRjh4/zFHpiMvQynUPDYG4WUJo8NpnuTfLbRUh0Z/CD90GvnCjp6kdltHpy9Lhy4KYqrsdFxAwX45NkftnBWyZL/4SYR0SlvWsHGfvdGeAm1MBeLmoHFJBEc0116qQF4dhL5ZQxVEy5dqKc18FzuUhNduoiz4TQlsHOw6g+brc9VoqOpzGxODfgGozHfIQyYU6uYtr68ksXNtabfOyGVPHZ8eGbdhtQ2AaD0/VxUdQIINDhSD+U886GvzA32LEduieaDiMtbn9k2eQiVQE0X4fNk61sQFsdrPPNk99S0QYugUc94vDLpUbVPtFlT66GAs8qFedY9xKc2YKAfoupMx0nsE4bHvXw8AKARZs4XB+w9aUGzux8msjM2GUPMogCsYWOrnC+4NI91SYGtWxXvnRW34q5mY3Z1QhZA2Rk1gGje25G/rpn5XkKtUttFsFe8IWHdff1k252HTiInSGTgp/Nnhjb16iN/r4ACWLHbBkqRNBAE/SeZWStFqWO3WnQlQMjYseosqsFBo9pmIpZJligzgndj8v5EhfTOr0Ian5iDrkeOYZ4oKZPAiEWtbnj5RaayzyZmfVdkGQ6o="
     - secure: "qM9BmDBPaj72YTJnvhYBm39uxvenQMEf/pEWzSeO6/B7FGfvtSxdUPz67G0QrGNsbOdUo2y/CppBCltqg/JUvpMHbrtO/vWgFUgPKrZNiyxjhvBjRIebOPc8vjXMeqCeOy5SOl33Uz6YlvYYvM4y9/sLDjgBdgPKHblMloik0r/k27BOo64avfbp0xN3HJAO6AYZ2O7wP5jmjUV8lMdr2O3BMVeP+TsXRr32BQ3SmO+sAvLiDgHnK6qjg9/3KF0GHFV4J044hQ3CXaucSPo0KeH3KarqRakQQ5WdO6m96jX88RrZDFzAJpSdRe/r9F4yDnVNYdECW4f5t2ENl3+LpEsS9LI3dyN3HN+z8t4bNI8J2NkAuUWGgspMIHP+poQSxy4i8009Dcv3CDp7viDpoTZX7dkYHKKodA2jFj3FId0fvaLlO++bvGtIjawrkKRpqH9rjn9jHy2bGl7AFmx8Ttop7p+elwaWXJ5xREWNIN5MXs0s5M402iPRgjibeQa1qp83w/eMQcwHv4LsjuJ1l9UVtXAzuCq/6GY2vc1Rqng64yqvDc9Up5rPJ3zWJbBV/t6vl/UHnAKagSpBoyhexvH73E6Ug449DWGAb7XrvcH3ZjvQdO0rjMULkrebk9SkDMrmvLrbEID2q1Yl/dAZCOTKihOnHV/xXXM9kLsGae8="
+    - BUCKET="${AWS_BUCKET_PREFIX}-img"
 
 matrix:
   include:
-    - env: branch=REL1_31
-      php: 7.2
+#    - env: branch=REL1_31
+#      php: 7.2
     - env: branch=REL1_27
       php: 7.1
-    - env: branch=REL1_27
-      php: 5.6
+#    - env: branch=REL1_27
+#      php: 5.6
 
 cache:
   directories:
@@ -50,14 +51,18 @@ before_script:
   - echo -en "\n\nrequire_once __DIR__ . '/extensions/AWS/tests/travis/AWSSettings.php';\n" >> ./LocalSettings.php
   - php -l ./LocalSettings.php
   - php maintenance/update.php --quick
-  - export AWS_S3_TEST_TOP_DIRECTORY="test$(LC_ALL=C date +'%s')-$TRAVIS_BUILD_ID-$TRAVIS_BUILD_NUMBER"
+  - export AWS_S3_TEST_TOP_DIRECTORY="test$(LC_ALL=C date +'%s')-$TRAVIS_JOB_NUMBER"
+  - echo $BUCKET
 
 script:
   - php tests/phpunit/phpunit.php extensions/AWS/tests/phpunit/
 
 after_script:
+  - echo $BUCKET
   - pip install --user awscli
   - mkdir -p ~/.aws
   - echo -en "\n[default]\naws_access_key_id = ${AWS_KEY}\naws_secret_access_key = ${AWS_SECRET}\n" >>~/.aws/credentials
   - echo -en "\n[default]\nregion = us-east-1\n" >>~/.aws/config
-  - ~/.local/bin/aws s3 rm --recursive "s3://${AWS_BUCKET_PREFIX}-img/${AWS_S3_TEST_TOP_DIRECTORY}"
+  - chmod 600 ~/.aws/*
+  - ~/.local/bin/aws s3 ls --recursive $BUCKET
+  - ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/${AWS_S3_TEST_TOP_DIRECTORY}

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,17 +52,17 @@ before_script:
   - php -l ./LocalSettings.php
   - php maintenance/update.php --quick
   - export AWS_S3_TEST_TOP_DIRECTORY="test$(LC_ALL=C date +'%s')-$TRAVIS_JOB_NUMBER"
-  - echo $BUCKET
 
 script:
   - php tests/phpunit/phpunit.php extensions/AWS/tests/phpunit/
 
 after_script:
-  - echo $BUCKET
   - pip install --user awscli
   - mkdir -p ~/.aws
   - echo -en "\n[default]\naws_access_key_id = ${AWS_KEY}\naws_secret_access_key = ${AWS_SECRET}\n" >>~/.aws/credentials
   - echo -en "\n[default]\nregion = us-east-1\n" >>~/.aws/config
   - chmod 600 ~/.aws/*
+  - echo $BUCKET
+  - echo $AWS_S3_TEST_TOP_DIRECTORY
   - ~/.local/bin/aws s3 ls --recursive $BUCKET
-  - ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/${AWS_S3_TEST_TOP_DIRECTORY}
+  - ~/.local/bin/aws s3 rm --recursive s3://$BUCKET/$AWS_S3_TEST_TOP_DIRECTORY

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ env:
 
 matrix:
   include:
-#    - env: branch=REL1_31
-#      php: 7.2
+    - env: branch=REL1_31
+      php: 7.2
     - env: branch=REL1_27
       php: 7.1
-#    - env: branch=REL1_27
-#      php: 5.6
+    - env: branch=REL1_27
+      php: 5.6
 
 cache:
   directories:
@@ -49,7 +49,6 @@ before_script:
   - echo -en "\n\nrequire_once __DIR__ . '/includes/DevelopmentSettings.php';\n" >> ./LocalSettings.php
   - echo -en "\n\nrequire_once __DIR__ . '/extensions/AWS/tests/travis/AWSSettings.php';\n" >> ./LocalSettings.php
   - php -l ./LocalSettings.php
-  - php maintenance/update.php --quick
   - export AWS_S3_TEST_TOP_DIRECTORY="Test$(LC_ALL=C date +'%s')-$TRAVIS_JOB_NUMBER"
 
 script:


### PR DESCRIPTION
1) $TRAVIS_JOB_NUMBER is now used as part of temporary directory (it's different for two parallel builds),
2) test directory prefix now starts with uppercase (MediaWiki does this anyway,
and after_script cleanup needs to delete S3 objects created by MediaWiki).
3) We no longer run update.php, because this extension doesn't need it,
and technically when saying it we should test that it works without it.