### PR TITLE
use wfWikiID() to cover using of $wgDBprefix

### DIFF
--- a/includes/AmazonS3Hooks.php
+++ b/includes/AmazonS3Hooks.php
@@ -91,10 +91,11 @@ class AmazonS3Hooks {
 				unset( $wgLocalFileRepo['zones'][$zone]['url'] );
 			}
 		}
-
+		//use wfWikiID() to cover using of $wfWikiID
+		$wikiId = wfWikiID();
 		$containerPaths = [];
 		foreach ( $zones as $zone ) {
-			$containerPaths["$wgDBname-local-$zone"] = self::getBucketName( $zone );
+			$containerPaths["$wikiId-local-$zone"] = self::getBucketName( $zone );
 		}
 		$wgFileBackends['s3']['containerPaths'] = $containerPaths;
 	}

--- a/includes/AmazonS3Hooks.php
+++ b/includes/AmazonS3Hooks.php
@@ -62,7 +62,7 @@ class AmazonS3Hooks {
 	 * Replace $wgLocalRepo with Amazon S3.
 	 */
 	protected static function replaceLocalRepo() {
-		global $wgFileBackends, $wgLocalFileRepo, $wgDBname;
+		global $wgFileBackends, $wgLocalFileRepo;
 
 		/* Needed zones */
 		$zones = [ 'public', 'thumb', 'deleted', 'temp' ];

--- a/includes/AmazonS3Hooks.php
+++ b/includes/AmazonS3Hooks.php
@@ -91,7 +91,8 @@ class AmazonS3Hooks {
 				unset( $wgLocalFileRepo['zones'][$zone]['url'] );
 			}
 		}
-		//use wfWikiID() to cover using of $wfWikiID
+
+		// Container names are prefixed by wfWikiID(), which depends on $wgDBPrefix and $wgDBname.
 		$wikiId = wfWikiID();
 		$containerPaths = [];
 		foreach ( $zones as $zone ) {

--- a/tests/phpunit/AmazonS3HooksTest.php
+++ b/tests/phpunit/AmazonS3HooksTest.php
@@ -71,12 +71,13 @@ class AmazonS3HooksTest extends MediaWikiTestCase {
 			'lockManager' => 'nullLockManager',
 
 		];
+		$wikiId = wfWikiID();
 		if ( $wgAWSBucketPrefix ) {
 			$expectedBackend['containerPaths'] = [
-				"$wgDBname-local-public" => "$wgAWSBucketPrefix",
-				"$wgDBname-local-thumb" => "$wgAWSBucketPrefix-thumb",
-				"$wgDBname-local-deleted" => "$wgAWSBucketPrefix-deleted",
-				"$wgDBname-local-temp" => "$wgAWSBucketPrefix-temp",
+				"$wikiId-local-public" => "$wgAWSBucketPrefix",
+				"$wikiId-local-thumb" => "$wgAWSBucketPrefix-thumb",
+				"$wikiId-local-deleted" => "$wgAWSBucketPrefix-deleted",
+				"$wikiId-local-temp" => "$wgAWSBucketPrefix-temp",
 			];
 		}
 


### PR DESCRIPTION
When adding $wgDBprefix in localSettings, this extension not working.

The reason:
The FileBackend::fullContainerName uses FileBackend->domainId which in turn populate by wfWikiID() function. The current hook populate $containerPaths keys by $wgDBname;
See: 

- aws/includes/AmazonS3Hooks.php line 97
- includes/libs/filebackend/FileBackend.php line 164
- includes/libs/filebackend/FileBackendStore.php line 1581
- includes/GlobalFunctions.php line 2751

So I change the code little bit to cover this settings.