### PR TITLE
Use EC2 instance profile if '$wgAWSCredentials' config does not present

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -116,16 +116,19 @@ class AmazonS3FileBackend extends FileBackendStore {
 			$this->memCache = $config['wanCache'];
 		}
 
-		$this->client = new S3Client( [
+		$params = [
 			'version' => '2006-03-01',
 			'region' => isset( $config['awsRegion'] ) ? $config['awsRegion'] : $wgAWSRegion,
-			'credentials' => [
+			'scheme' => $this->useHTTPS ? 'https' : 'http'
+		];
+		if ( isset( $wgAWSCredentials ) ) {
+			$params['credentials'] = [
 				'key' => isset( $config['awsKey'] ) ? $config['awsKey'] : $wgAWSCredentials['key'],
 				'secret' => isset( $config['awsSecret'] ) ? $config['awsSecret'] : $wgAWSCredentials['secret'],
 				'token' => isset( $config['awsToken'] ) ? $config['awsToken'] : $wgAWSCredentials['token'],
-			],
-			'scheme' => $this->useHTTPS ? 'https' : 'http'
-		] );
+			];
+		}
+		$this->client = new S3Client($params);
 
 		if ( isset( $config['containerPaths'] ) ) {
 			$this->containerPaths = (array)$config['containerPaths'];


### PR DESCRIPTION
AWS SDK won't try to use instance profile if 'credentials' option is given.

###### Reference
- https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.AwsClient.html#___construct