### PR TITLE
Allow specifying custom endpoint

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -137,6 +137,10 @@ class AmazonS3FileBackend extends FileBackendStore {
 			];
 		}
 
+        if (isset($config['endpoint'])) {
+            $params['endpoint'] = $config['endpoint'];
+        }
+
 		$this->client = new S3Client( $params );
 
 		if ( isset( $config['containerPaths'] ) ) {

--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -137,9 +137,9 @@ class AmazonS3FileBackend extends FileBackendStore {
 			];
 		}
 
-        if (isset($config['endpoint'])) {
-            $params['endpoint'] = $config['endpoint'];
-        }
+		if ( isset( $config['endpoint'] ) ) {
+			$params['endpoint'] = $config['endpoint'];
+		}
 
 		$this->client = new S3Client( $params );
 


### PR DESCRIPTION
Simple change to allow use with non-AWS storage providers supporting the S3 interface.