### PR TITLE
Don't include vendor/autoload.php if S3Client is already loaded

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -21,8 +21,8 @@
  * @file
  */
 
-if ( !class_exists("\\Aws\\S3\\S3Client") ) {
-    require_once __DIR__ . '/../vendor/autoload.php';
+if ( !class_exists( "\\Aws\\S3\\S3Client" ) ) {
+	require_once __DIR__ . '/../vendor/autoload.php';
 }
 
 use Aws\S3\S3Client;

--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -21,7 +21,9 @@
  * @file
  */
 
-require_once __DIR__ . '/../vendor/autoload.php';
+if ( !class_exists("\\Aws\\S3\\S3Client") ) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
 
 use Aws\S3\S3Client;
 use Aws\S3\Exception\S3Exception;


### PR DESCRIPTION
When Mediawiki's composer.local.json file is used to install
dependencies for the AWS extension the AWS classes will already
be autoloaded when requested by the extension. Existing users
may still be running "composer install" within the extension
folder and generating an autoload.php file, so the absence of
the S3 classes will continue to triger this old behavior for
compatibility.