### PR TITLE
Add support for sharding

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -119,9 +119,9 @@ class AmazonS3FileBackend extends FileBackendStore {
 			$this->useHTTPS = (bool)$wgAWSUseHTTPS;
 		}
 
-		if ( isset ( $config['shardViaHashLevels'] ) ) {
-            $this->shardViaHashLevels = $config['shardViaHashLevels'];
-        }
+		if ( isset( $config['shardViaHashLevels'] ) ) {
+			$this->shardViaHashLevels = $config['shardViaHashLevels'];
+		}
 
 		// Cache container information to mask latency
 		if ( isset( $config['wanCache'] ) && $config['wanCache'] instanceof WANObjectCache ) {

--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -119,6 +119,10 @@ class AmazonS3FileBackend extends FileBackendStore {
 			$this->useHTTPS = (bool)$wgAWSUseHTTPS;
 		}
 
+		if ( isset ( $config['shardViaHashLevels'] ) ) {
+            $this->shardViaHashLevels = $config['shardViaHashLevels'];
+        }
+
 		// Cache container information to mask latency
 		if ( isset( $config['wanCache'] ) && $config['wanCache'] instanceof WANObjectCache ) {
 			$this->memCache = $config['wanCache'];


### PR DESCRIPTION
* MediaWiki already provides support for sharding backend storage
  in FileBackendStore, file backends inheriting from this need
  only set the shardViaHashLevels property to enable it.

If somebody wants or I get the time it's possible to add support for generating the proper configuration for sharded buckets, but this simply setting the property if passed is enough to get everything to work if you manually configure the containerPaths and shardViaHashLevels properties.