### PR TITLE
Avoid the use of deprecated wfSuppressWarnings()

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -639,9 +639,11 @@ class AmazonS3FileBackend extends FileBackendStore {
 					continue;
 				}
 
-				wfSuppressWarnings();
-				$ok = copy( $srcPath, $dstPath );
-				wfRestoreWarnings();
+				$ok = false;
+				$contents = Http::get( $srcPath );
+				if ( $contents ) {
+					$ok = ( file_put_contents( $dstPath, $contents ) !== false );
+				}
 
 				$this->logger->log(
 					$ok ? LogLevel::DEBUG : LogLevel::ERROR,


### PR DESCRIPTION
The wfSuppressWarnings and wfRestoreWarnings functions were
deprecated in MediaWiki 1.26 and removed in 1.34. This change
switches to using Wikimedia\AtEase\AtEase::suppressWarnings().

https://www.mediawiki.org/wiki/Release_notes/1.34#Breaking_changes_in_1.34