### PR TITLE
Fix guzzle version conflict issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     # Phan (PHP static analyzer)
     - &phan-build
       name: "Phan"
-      if: branch IN (phan,master)
+      if: branch IN (phan,master,composer-test)
       env: TESTSUITE_TYPE=phan branch=REL1_35
       php: 7.3
       before_script:
@@ -48,10 +48,9 @@ matrix:
         - php -i
         - bash -ex ./tests/travis/build_mediawiki.sh "$branch"
         - rsync -a --exclude buildcache --exclude mediawiki --exclude .git . mediawiki/extensions/AWS/
-        - cd mediawiki
-        - ( cd extensions/AWS && composer install )
-      script:
-        - ( cd extensions/AWS && ./vendor/bin/phan --analyze-twice )
+        - cd mediawiki/extensions/AWS
+        - composer install
+      script: ./vendor/bin/phan --analyze-twice
     - <<: *phan-build
       name: "Phan (PHAN_CHECK_TESTSUITE=1)"
       if: branch IN (phan,phpunit)
@@ -91,8 +90,8 @@ before_script:
   - phpenv config-rm xdebug.ini
   - bash -ex ./tests/travis/build_mediawiki.sh "$branch"
   - rsync -a --exclude buildcache --exclude mediawiki --exclude .git * mediawiki/extensions/AWS/
-  - cd mediawiki/extensions/AWS && composer install --no-dev --ignore-platform-reqs && cd -
   - cd mediawiki
+  - cp extensions/AWS/tests/travis/composer.local.json . && composer update
   - >
       php maintenance/install.php traviswiki admin
       --pass $(dd if=/dev/urandom count=1 bs=20 2>/dev/null | base64)

--- a/README.md
+++ b/README.md
@@ -6,19 +6,34 @@ Why is this needed: when images are in S3, Amazon EC2 instance which runs MediaW
 
 # Installation
 
+*Note: This version of Extension:AWS requires MediaWiki 1.35+. For older versions of MediaWiki (1.27-1.34) use the following instructions instead: https://github.com/edwardspec/mediawiki-aws-s3/blob/REL1_34/README.md*
+
 1\) Download the extension: `git clone --depth 1 https://github.com/edwardspec/mediawiki-aws-s3.git AWS`
 
-2\) Move the AWS directory to the "extensions" directory of your MediaWiki, e.g. `/var/www/html/w/extensions` (assuming MediaWiki is in `/var/www/html/w`).
+2\) Move the AWS directory to the "extensions" directory of your MediaWiki, e.g. `/var/www/html/w/extensions` __(assuming MediaWiki is in `/var/www/html/w`)__.
 
-3\) Run `composer install` from `/var/www/html/w/extensions/AWS` (to download dependencies). If you don't have Composer installed, see https://www.mediawiki.org/wiki/Composer for how to install it.
+3\) Create the file `/var/www/html/w/composer.local.json` with the following contents:
+```json
+{
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/AWS/composer.json"
+			]
+		}
+	}
+}
+```
 
-4\) Create an S3 bucket for images, e.g. `wonderfulbali234`. Note: this name will be seen in URL of images.
+4\) Run `composer update` from `/var/www/html/w` (to download dependencies). If you don't have Composer installed, see https://www.mediawiki.org/wiki/Composer for how to install it.
 
-5a\) If your EC2 instance has an IAM instance profile (recommended), copy everything from "Needed IAM permissions" (see below) to inline policy of the IAM role. See https://console.aws.amazon.com/iam/home#/roles
+5\) Create an S3 bucket for images, e.g. `wonderfulbali234`. Note: this name will be seen in URL of images.
 
-5b\) If your EC2 instance doesn't have an IAM profile, obtain key/secret for AWS API. You'll need to write it in LocalSettings.php (see below).
+6a\) If your EC2 instance has an IAM instance profile (recommended), copy everything from "Needed IAM permissions" (see below) to inline policy of the IAM role. See https://console.aws.amazon.com/iam/home#/roles
 
-6\) Modify LocalSettings.php (see below).
+6b\) If your EC2 instance doesn't have an IAM profile, obtain key/secret for AWS API. You'll need to write it in LocalSettings.php (see below).
+
+7\) Modify LocalSettings.php (see below).
 
 # Configuration in LocalSettings.php
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
 	},
 	"require": {
 		"aws/aws-sdk-php": "^3.67",
-		"composer/installers": "^1.5",
-		"guzzlehttp/guzzle": "6.3.3"
+		"composer/installers": "^1.5"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "1.2.0",

--- a/extension.json
+++ b/extension.json
@@ -10,6 +10,9 @@
 	"url": "https://www.mediawiki.org/wiki/Extension:AWS",
 	"descriptionmsg": "aws-desc",
 	"license-name": "GPL-2.0+",
+	"requires": {
+		"MediaWiki": ">= 1.35.0"
+	},
 	"type": "other",
 	"MessagesDirs": {
 		"AWS": [

--- a/tests/travis/composer.local.json
+++ b/tests/travis/composer.local.json
@@ -1,0 +1,9 @@
+{
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/AWS/composer.json"
+			]
+		}
+	}
+}


### PR DESCRIPTION
* Removes explicity dependency on guzzle in favor of implicit dependency
  via MediaWiki requirements
* Adds requirement for MediaWiki v1.35 (older versions to be supported
  via branch)

Relevant conversation:
https://github.com/edwardspec/mediawiki-aws-s3/pull/32#issuecomment-739649057