### PR TITLE
Added support for path style endpoints 

### DIFF
--- a/includes/AmazonS3Hooks.php
+++ b/includes/AmazonS3Hooks.php
@@ -223,6 +223,10 @@ class AmazonS3Hooks {
 			$domain
 		);
 
-		return 'https://' . $domain . $this->getS3RootDir( $zone );
+		if ( !preg_match( '@^https?://@', $domain ) ) {
+			$domain = 'https://' . $domain;
+		}
+
+		return $domain . $this->getS3RootDir( $zone );
 	}
 }

--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -141,6 +141,9 @@ class AmazonS3FileBackend extends FileBackendStore {
 		if ( isset( $config['endpoint'] ) ) {
 			$params['endpoint'] = $config['endpoint'];
 		}
+		if ( isset( $config['use_path_style_endpoint'] ) ) {
+			$params['use_path_style_endpoint'] = $config['use_path_style_endpoint'];
+		}
 
 		$this->client = new S3Client( $params );
 


### PR DESCRIPTION
In case users use a non AWS S3 storage backend that doesn't support bucket domains you wan't to enable the option `use_path_style_endpoint` on the S3Client.
In this PR I have added support to pass this on to the S3Client.

I have also enabled support of added the scheme to `$wgAWSBucketDomain` so the extension also work on testing environments where HTTPS is not set up.

With the following configuration it is now possible to use this extension with Minio (#46):
```php
wfLoadExtension( 'AWS' );
$wgAWSCredentials = [
	'key' => 'minioadmin',
	'secret' => 'minioadmin',
	'token' => false
];
$wgAWSRegion = 'dev';
$wgAWSBucketName = 'images';
$wgAWSBucketDomain = 'http://localhost:9000/$1';
$wgFileBackends['s3']['endpoint'] = 'http://localhost:9000';
$wgFileBackends['s3']['use_path_style_endpoint'] = true;
```

