### PR TITLE
bugfix: fix calling S3 if we know the file doesn't exist

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -620,7 +620,7 @@ class AmazonS3FileBackend extends FileBackendStore {
 			// 0 is not identical (===) to false, so the cache miss check won't trigger again until the cache expires
 			// otherwise, the value of $result will always be false and the statUncached function will always
 			// run even if the cache entry says the image doesn't exist
-			$valueForCache = ($result === false) ? 0 : $result;
+			$valueForCache = ( $result === false ) ? 0 : $result;
 
 			$this->statCache->set( $cacheKey, $valueForCache, 604800 ); // 7 days, since we invalidate the cache
 		}


### PR DESCRIPTION
I've been having major latency problems recently with this extension and it repeatedly calling out to S3 to check whether an image exists - I suspect that is not actually related to this extension (it appears a different extension is asking for a thumbnail of files which is identical to the original image, which MediaWiki will obviously refuse to thumbnail, so the file will never exist, but that is outside the scope of this PR or bugfix).

Anyway, that aside, this led me to some debugging and I believe there is a flaw in the logic on [this line](https://github.com/edwardspec/mediawiki-aws-s3/blob/68482102c379b7a35c8055653a54851b55f63c55/s3/AmazonS3FileBackend.php#L615). Specifically, here:
```php
protected function doGetFileStat( array $params ) {
		$src = $params['src'];
		$cacheKey = $this->getStatCacheKey( $src );

		$result = $this->statCache->get( $cacheKey );
		if ( $result === false ) { /* Not found in the cache */
			$result = $this->statUncached( $src );
			$this->statCache->set( $cacheKey, $result, 604800 ); // 7 days, since we invalidate the cache
		}

		return $result;
	}
```
This function runs and checks if we have information in the cache for this particular file. If the return from `$result` is false, we call out to S3 to check the existence of the file. Later, in `statUncached()`, we return false, and log the error if the result was "NotFound" from S3. This is important. 

We then save this value to the cache. Later, when we load the page again, we lookup the cache key. The result will be false if the key doesn't exist OR if the file doesn't exist, since we wrote "false" to the cache on previously. This causes us to infinitely call out to S3 every time we load that page because MediaWiki's object cache returns false also if the key doesn't exist. 

The `if` statement is only meant to check with S3 IF the key doesn't exist in the cache, but because MediaWiki cannot tell the difference between false returned by the cache when the key doesn't exist, or false returned because we previously wrote this to the cache, we check S3 again, and again, and again. 

I'm not sure if this is intentional or not? Notwithstanding the fact that another extension - I haven't narrowed down which yet - is causing this behaviour, this feels like a logic flaw in any case that is causing unecessary calls to S3 when we know the image doesn't exist. 

My proposed fix is the following:

```php
protected function doGetFileStat( array $params ) {
		$src = $params['src'];
		$cacheKey = $this->getStatCacheKey( $src );

		$result = $this->statCache->get( $cacheKey );

		if ( $result === false ) {
			$result = $this->statUncached( $src );

			// statUncached returned false which means the FILE DOES NOT EXIST, store 0 in the cache instead
			// 0 is not identical (===) to false, so the cache miss check won't trigger again until the cache expires
			// otherwise, the value of $result will always be false and the statUncached function will always
			// run even if the cache entry says the image doesn't exist
			$valueForCache = ($result === false) ? 0 : $result;

			$this->statCache->set( $cacheKey, $valueForCache, 604800 ); // 7 days, since we invalidate the cache
		}

		// Convert back to false so MediaWiki can understand that the file doesn't exist
		if ( $result === 0 ) {
			return false;
		}

		return $result;
	}
```
We simply save `0` (or some other value) to the cache instead. Since 0 and false !=== then we can be assured that the if statement only runs if the key actually doesn't exist. 

**Tl;dr:** is this intended functionality or an actual bug? In any case, it was causing significant amounts of calls to S3 for me for no reason :)