### PR TITLE
pin psr/http-message to 1.1 to avoid autoloader conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	},
 	"require": {
 		"php": ">= 8.1",
-		"psr/http-message": "1.1.*",
+		"psr/http-message": "^1.1",
 		"aws/aws-sdk-php": "^3.67",
 		"composer/installers": "^1 || ^2"
 	},

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 	},
 	"require": {
 		"php": ">= 8.1",
+		"psr/http-message": "1.1.*",
 		"aws/aws-sdk-php": "^3.67",
 		"composer/installers": "^1 || ^2"
 	},


### PR DESCRIPTION
When psr/http-message is at ^2.0 any version <1.46 will break due to missing the return types which will break the rest api